### PR TITLE
Fixes path from which to copy the ".a"s from.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,15 @@ $(PODS_PROJECT):
 
 $(LIB_NAME_I386): $(PODS_PROJECT)
 	$(XBUILD) -project $(PODS_PROJECT) -target $(PODS_TARGET) -sdk iphonesimulator -configuration Release clean build
-	-mv $(PODS_PROJECT_ROOT)/build/Release-iphonesimulator/lib$(PODS_TARGET).a $@
+	-mv $(PROJECT_ROOT)/build/Release-iphonesimulator/lib$(PODS_TARGET).a $@
 
 $(LIB_NAME_ARMV7): $(PODS_PROJECT)
 	$(XBUILD) -project $(PODS_PROJECT) -target $(PODS_TARGET) -sdk iphoneos -arch armv7 -configuration Release clean build
-	-mv $(PODS_PROJECT_ROOT)/build/Release-iphoneos/lib$(PODS_TARGET).a $@
+	-mv $(PROJECT_ROOT)/build/Release-iphoneos/lib$(PODS_TARGET).a $@
 	
 $(LIB_NAME_ARMV7S): $(PODS_PROJECT)
 	$(XBUILD) -project $(PODS_PROJECT) -target $(PODS_TARGET) -sdk iphoneos -arch armv7s -configuration Release clean build
-	-mv $(PODS_PROJECT_ROOT)/build/Release-iphoneos/lib$(PODS_TARGET).a $@
+	-mv $(PROJECT_ROOT)/build/Release-iphoneos/lib$(PODS_TARGET).a $@
 
 $(LIB_NAME): $(LIB_NAME_I386) $(LIB_NAME_ARMV7) $(LIB_NAME_ARMV7S)
 	lipo -create -output $@ $^


### PR DESCRIPTION
The build was not working on Xcode 6.3, but I'm not sure if it's only on it, all I know is that this fixes the build.
